### PR TITLE
Replace Heading with Text component in spacing stories

### DIFF
--- a/src/stories/SpacingGuidelines.stories.tsx
+++ b/src/stories/SpacingGuidelines.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Container } from './Container';
 import { Card } from './Card';
 import { Text } from './Text';
-import { Heading } from './Heading';
 import { Button } from './Button';
 import { Badge } from './Badge';
 import { Group, Stack } from './Flex';
@@ -106,13 +105,13 @@ export const CardSpacingExample: Story = {
     <Container size="lg">
       <div style={{ padding: tokens.spacing[8] }}>
         <div style={{ marginBottom: tokens.spacing[8] }}>
-          <Heading level={1}>Card Spacing Examples</Heading>
+          <Text component="h1" size="3xl" fw="bold">Card Spacing Examples</Text>
         </div>
         
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: tokens.spacing[8] }}>
           <Card padding="xl" radius="md" withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
-              <Heading level={3}>Proper Card Spacing</Heading>
+              <Text component="h3" size="lg" fw="semibold">Proper Card Spacing</Text>
             </div>
             <div style={{ marginBottom: tokens.spacing[5] }}>
               <Text size="sm" c="dimmed">This card demonstrates proper internal spacing</Text>
@@ -128,7 +127,7 @@ export const CardSpacingExample: Story = {
 
           <Card padding="xl" radius="md" withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
-              <Heading level={3}>With Badge and Actions</Heading>
+              <Text component="h3" size="lg" fw="semibold">With Badge and Actions</Text>
             </div>
             <div style={{ marginBottom: tokens.spacing[5] }}>
               <Badge color="primary" variant="filled">Featured</Badge>
@@ -170,13 +169,13 @@ export const TypographySpacingExample: Story = {
     <Container size="md">
       <div style={{ padding: tokens.spacing[8] }}>
         <div style={{ marginBottom: tokens.spacing[10] }}>
-          <Heading level={1}>Typography Spacing Guidelines</Heading>
+          <Text component="h1" size="3xl" fw="bold">Typography Spacing Guidelines</Text>
         </div>
         
         <Stack gap={tokens.spacing[8]}>
           <div>
             <div style={{ marginBottom: tokens.spacing[4] }}>
-              <Heading level={2}>Section Heading</Heading>
+              <Text component="h2" size="2xl" fw="semibold">Section Heading</Text>
             </div>
             <div style={{ marginBottom: tokens.spacing[5] }}>
               <Text>
@@ -198,7 +197,7 @@ export const TypographySpacingExample: Story = {
 
           <div>
             <div style={{ marginBottom: tokens.spacing[4] }}>
-              <Heading level={2}>Another Section</Heading>
+              <Text component="h2" size="2xl" fw="semibold">Another Section</Text>
             </div>
             <div style={{ marginBottom: tokens.spacing[6] }}>
               <Text size="lg">
@@ -237,7 +236,7 @@ export const LayoutSpacingExample: Story = {
       <Container size="xl">
         <div style={{ padding: `${tokens.spacing[12]} 0` }}>
           <div style={{ marginBottom: tokens.spacing[12] }}>
-            <Heading level={1}>Layout Spacing Standards</Heading>
+            <Text component="h1" size="3xl" fw="bold">Layout Spacing Standards</Text>
             <div style={{ marginTop: tokens.spacing[4] }}>
               <Text size="lg" c="dimmed">
                 Demonstrating page-level spacing and layout patterns
@@ -248,7 +247,7 @@ export const LayoutSpacingExample: Story = {
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: tokens.spacing[10] }}>
             <Card padding="xl" radius="md" withBorder>
               <div style={{ marginBottom: tokens.spacing[6] }}>
-                <Heading level={3}>Page Structure</Heading>
+                <Text component="h3" size="lg" fw="semibold">Page Structure</Text>
                 <div style={{ marginTop: tokens.spacing[3] }}>
                   <Text size="sm" c="dimmed">Vertical spacing guidelines</Text>
                 </div>
@@ -263,7 +262,7 @@ export const LayoutSpacingExample: Story = {
 
             <Card padding="xl" radius="md" withBorder>
               <div style={{ marginBottom: tokens.spacing[6] }}>
-                <Heading level={3}>Grid Guidelines</Heading>
+                <Text component="h3" size="lg" fw="semibold">Grid Guidelines</Text>
                 <div style={{ marginTop: tokens.spacing[3] }}>
                   <Text size="sm" c="dimmed">Horizontal spacing patterns</Text>
                 </div>

--- a/src/stories/SpacingGuidelines.stories.tsx
+++ b/src/stories/SpacingGuidelines.stories.tsx
@@ -110,7 +110,7 @@ export const CardSpacingExample: Story = {
         </div>
         
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: tokens.spacing[8] }}>
-          <CustomCard shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+          <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
               <Heading level={3}>Proper Card Spacing</Heading>
             </div>
@@ -124,9 +124,9 @@ export const CardSpacingExample: Story = {
               </Text>
             </div>
             <Button size="sm">Learn More</Button>
-          </CustomCard>
+          </Card>
 
-          <CustomCard shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+          <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
               <Heading level={3}>With Badge and Actions</Heading>
             </div>
@@ -143,7 +143,7 @@ export const CardSpacingExample: Story = {
               <Button variant="outline" size="sm">Cancel</Button>
               <Button size="sm">Continue</Button>
             </Group>
-          </CustomCard>
+          </Card>
         </div>
       </div>
     </Container>
@@ -246,7 +246,7 @@ export const LayoutSpacingExample: Story = {
           </div>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: tokens.spacing[10] }}>
-            <CustomCard shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+            <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
               <div style={{ marginBottom: tokens.spacing[6] }}>
                 <Heading level={3}>Page Structure</Heading>
                 <div style={{ marginTop: tokens.spacing[3] }}>
@@ -259,9 +259,9 @@ export const LayoutSpacingExample: Story = {
                 <Text size="sm">• Content blocks: 24-32px spacing</Text>
                 <Text size="sm">• Related elements: 16-20px gaps</Text>
               </Stack>
-            </CustomCard>
+            </Card>
 
-            <CustomCard shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+            <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
               <div style={{ marginBottom: tokens.spacing[6] }}>
                 <Heading level={3}>Grid Guidelines</Heading>
                 <div style={{ marginTop: tokens.spacing[3] }}>
@@ -274,7 +274,7 @@ export const LayoutSpacingExample: Story = {
                 <Text size="sm">• Button groups: 16px related, 24px separated</Text>
                 <Text size="sm">• Minimum card width: 300px for readability</Text>
               </Stack>
-            </CustomCard>
+            </Card>
           </div>
         </div>
       </Container>

--- a/src/stories/SpacingGuidelines.stories.tsx
+++ b/src/stories/SpacingGuidelines.stories.tsx
@@ -110,7 +110,7 @@ export const CardSpacingExample: Story = {
         </div>
         
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: tokens.spacing[8] }}>
-          <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+          <Card padding="xl" radius="md" withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
               <Heading level={3}>Proper Card Spacing</Heading>
             </div>
@@ -126,7 +126,7 @@ export const CardSpacingExample: Story = {
             <Button size="sm">Learn More</Button>
           </Card>
 
-          <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+          <Card padding="xl" radius="md" withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
               <Heading level={3}>With Badge and Actions</Heading>
             </div>
@@ -246,7 +246,7 @@ export const LayoutSpacingExample: Story = {
           </div>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: tokens.spacing[10] }}>
-            <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+            <Card padding="xl" radius="md" withBorder>
               <div style={{ marginBottom: tokens.spacing[6] }}>
                 <Heading level={3}>Page Structure</Heading>
                 <div style={{ marginTop: tokens.spacing[3] }}>
@@ -261,7 +261,7 @@ export const LayoutSpacingExample: Story = {
               </Stack>
             </Card>
 
-            <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+            <Card padding="xl" radius="md" withBorder>
               <div style={{ marginBottom: tokens.spacing[6] }}>
                 <Heading level={3}>Grid Guidelines</Heading>
                 <div style={{ marginTop: tokens.spacing[3] }}>

--- a/src/stories/SpacingGuidelines.stories.tsx
+++ b/src/stories/SpacingGuidelines.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Container } from './Container';
-import { CustomCard } from './CustomCard';
+import { Card } from './Card';
 import { Text } from './Text';
 import { Heading } from './Heading';
 import { Button } from './Button';

--- a/src/stories/SpacingGuidelines.stories.tsx
+++ b/src/stories/SpacingGuidelines.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Container } from './Container';
 import { CustomCard } from './CustomCard';
 import { Text } from './Text';
-
+import { Heading } from './Heading';
 import { Button } from './Button';
 import { Badge } from './Badge';
 import { Group, Stack } from './Flex';

--- a/src/stories/SpacingIssues.stories.tsx
+++ b/src/stories/SpacingIssues.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { SimpleGrid } from './SimpleGrid';
-import { CustomCard } from './CustomCard';
+import { Card } from './Card';
 import { Text } from './Text';
 import { Heading } from './Heading';
 import { Button } from './Button';

--- a/src/stories/SpacingIssues.stories.tsx
+++ b/src/stories/SpacingIssues.stories.tsx
@@ -214,7 +214,7 @@ export const BeforeAndAfterComparison: Story = {
             <Text size="sm" c="dimmed">Tight spacing hurts readability</Text>
           </div>
           
-          <Card shadow="sm" padding="16px" radius={tokens.borderRadius.md} withBorder>
+          <Card style={{ padding: '16px' }} radius="md" withBorder>
             <Heading level={3} style={{ marginBottom: '8px' }}>Quick Actions</Heading>
             <Badge color="primary">Important</Badge>
             <Text size="sm" c="dimmed" style={{ margin: '4px 0 8px 0' }}>
@@ -234,7 +234,7 @@ export const BeforeAndAfterComparison: Story = {
             <Text size="sm" c="dimmed">Proper spacing improves clarity</Text>
           </div>
           
-          <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+          <Card padding="xl" radius="md" withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
               <Heading level={3}>Quick Actions</Heading>
             </div>

--- a/src/stories/SpacingIssues.stories.tsx
+++ b/src/stories/SpacingIssues.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SimpleGrid } from './SimpleGrid';
 import { CustomCard } from './CustomCard';
 import { Text } from './Text';
-
+import { Heading } from './Heading';
 import { Button } from './Button';
 import { Badge } from './Badge';
 import { tokens } from '../tokens/design-tokens';

--- a/src/stories/SpacingIssues.stories.tsx
+++ b/src/stories/SpacingIssues.stories.tsx
@@ -214,7 +214,7 @@ export const BeforeAndAfterComparison: Story = {
             <Text size="sm" c="dimmed">Tight spacing hurts readability</Text>
           </div>
           
-          <CustomCard shadow="sm" padding="16px" radius={tokens.borderRadius.md} withBorder>
+          <Card shadow="sm" padding="16px" radius={tokens.borderRadius.md} withBorder>
             <Heading level={3} style={{ marginBottom: '8px' }}>Quick Actions</Heading>
             <Badge color="primary">Important</Badge>
             <Text size="sm" c="dimmed" style={{ margin: '4px 0 8px 0' }}>
@@ -224,7 +224,7 @@ export const BeforeAndAfterComparison: Story = {
               <Button size="sm">Create</Button>
               <Button variant="outline" size="sm">Cancel</Button>
             </div>
-          </CustomCard>
+          </Card>
         </div>
 
         {/* AFTER - Good spacing */}
@@ -234,7 +234,7 @@ export const BeforeAndAfterComparison: Story = {
             <Text size="sm" c="dimmed">Proper spacing improves clarity</Text>
           </div>
           
-          <CustomCard shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
+          <Card shadow="sm" padding={tokens.spacing[8]} radius={tokens.borderRadius.md} withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
               <Heading level={3}>Quick Actions</Heading>
             </div>
@@ -250,7 +250,7 @@ export const BeforeAndAfterComparison: Story = {
               <Button size="sm">Create</Button>
               <Button variant="outline" size="sm">Cancel</Button>
             </div>
-          </CustomCard>
+          </Card>
         </div>
       </div>
       

--- a/src/stories/SpacingIssues.stories.tsx
+++ b/src/stories/SpacingIssues.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SimpleGrid } from './SimpleGrid';
 import { Card } from './Card';
 import { Text } from './Text';
-import { Heading } from './Heading';
 import { Button } from './Button';
 import { Badge } from './Badge';
 import { tokens } from '../tokens/design-tokens';
@@ -46,7 +45,7 @@ export const CrowdedLayoutProblem: Story = {
   render: () => (
     <div style={{ padding: tokens.spacing[8] }}>
       <div style={{ marginBottom: tokens.spacing[8] }}>
-        <Heading level={1}>❌ Crowded Layout - Common Problems</Heading>
+        <Text component="h1" size="3xl" fw="bold">❌ Crowded Layout - Common Problems</Text>
         <div style={{ marginTop: tokens.spacing[4] }}>
           <Text c="dimmed">This example shows what NOT to do - cramped spacing that hurts readability</Text>
         </div>
@@ -70,9 +69,9 @@ export const CrowdedLayoutProblem: Story = {
             }}
           >
             {/* No spacing wrappers - everything crammed together */}
-            <Heading level={3} style={{ margin: 0 }}>
+            <Text component="h3" size="lg" fw="semibold" style={{ margin: 0 }}>
               {product.title}
-            </Heading>
+            </Text>
             <Badge color="primary" variant="filled">New</Badge>
             <Text size="sm" c="dimmed" style={{ margin: 0 }}>
               {product.description}
@@ -85,7 +84,7 @@ export const CrowdedLayoutProblem: Story = {
       </SimpleGrid>
       
       <div style={{ marginTop: tokens.spacing[8], padding: tokens.spacing[6], backgroundColor: tokens.color.error[50], borderRadius: tokens.borderRadius.md }}>
-        <Heading level={3}>Problems with this layout:</Heading>
+        <Text component="h3" size="lg" fw="semibold">Problems with this layout:</Text>
         <ul style={{ marginTop: tokens.spacing[4] }}>
           <li><Text size="sm">Card padding too small (12px) - content feels cramped</Text></li>
           <li><Text size="sm">Grid gap too tight (12px) - cards feel connected</Text></li>
@@ -118,7 +117,7 @@ export const ProperLayoutSolution: Story = {
   render: () => (
     <div style={{ padding: tokens.spacing[8] }}>
       <div style={{ marginBottom: tokens.spacing[8] }}>
-        <Heading level={1}>✅ Proper Layout - Design System Standards</Heading>
+        <Text component="h1" size="3xl" fw="bold">✅ Proper Layout - Design System Standards</Text>
         <div style={{ marginTop: tokens.spacing[4] }}>
           <Text c="dimmed">This example shows the correct way to implement spacing for professional layouts</Text>
         </div>
@@ -143,9 +142,9 @@ export const ProperLayoutSolution: Story = {
           >
             {/* Explicit spacing wrappers for control */}
             <div style={{ marginBottom: tokens.spacing[4] }}>
-              <Heading level={3}>
+              <Text component="h3" size="lg" fw="semibold">
                 {product.title}
-              </Heading>
+              </Text>
             </div>
             <div style={{ marginBottom: tokens.spacing[5] }}>
               <Badge color="primary" variant="filled">New</Badge>
@@ -163,7 +162,7 @@ export const ProperLayoutSolution: Story = {
       </SimpleGrid>
       
       <div style={{ marginTop: tokens.spacing[10], padding: tokens.spacing[8], backgroundColor: tokens.color.success[50], borderRadius: tokens.borderRadius.md }}>
-        <Heading level={3}>Improvements in this layout:</Heading>
+        <Text component="h3" size="lg" fw="semibold">Improvements in this layout:</Text>
         <ul style={{ marginTop: tokens.spacing[4] }}>
           <li><Text size="sm">Generous card padding (32px) - content has breathing room</Text></li>
           <li><Text size="sm">Proper grid gaps (32px) - clear separation between cards</Text></li>
@@ -200,7 +199,7 @@ export const BeforeAndAfterComparison: Story = {
   render: () => (
     <div style={{ padding: tokens.spacing[8] }}>
       <div style={{ marginBottom: tokens.spacing[10] }}>
-        <Heading level={1}>Before vs After: Spacing Transformation</Heading>
+        <Text component="h1" size="3xl" fw="bold">Before vs After: Spacing Transformation</Text>
         <div style={{ marginTop: tokens.spacing[4] }}>
           <Text c="dimmed">Side-by-side comparison showing the dramatic improvement proper spacing makes</Text>
         </div>
@@ -210,12 +209,12 @@ export const BeforeAndAfterComparison: Story = {
         {/* BEFORE - Bad spacing */}
         <div>
           <div style={{ marginBottom: tokens.spacing[6] }}>
-            <Heading level={2}>❌ Before: Crowded</Heading>
+            <Text component="h2" size="2xl" fw="semibold">❌ Before: Crowded</Text>
             <Text size="sm" c="dimmed">Tight spacing hurts readability</Text>
           </div>
           
           <Card style={{ padding: '16px' }} radius="md" withBorder>
-            <Heading level={3} style={{ marginBottom: '8px' }}>Quick Actions</Heading>
+            <Text component="h3" size="lg" fw="semibold" style={{ marginBottom: '8px' }}>Quick Actions</Text>
             <Badge color="primary">Important</Badge>
             <Text size="sm" c="dimmed" style={{ margin: '4px 0 8px 0' }}>
               Common tasks you can perform
@@ -230,13 +229,13 @@ export const BeforeAndAfterComparison: Story = {
         {/* AFTER - Good spacing */}
         <div>
           <div style={{ marginBottom: tokens.spacing[6] }}>
-            <Heading level={2}>✅ After: Spacious</Heading>
+            <Text component="h2" size="2xl" fw="semibold">✅ After: Spacious</Text>
             <Text size="sm" c="dimmed">Proper spacing improves clarity</Text>
           </div>
           
           <Card padding="xl" radius="md" withBorder>
             <div style={{ marginBottom: tokens.spacing[4] }}>
-              <Heading level={3}>Quick Actions</Heading>
+              <Text component="h3" size="lg" fw="semibold">Quick Actions</Text>
             </div>
             <div style={{ marginBottom: tokens.spacing[5] }}>
               <Badge color="primary">Important</Badge>
@@ -255,7 +254,7 @@ export const BeforeAndAfterComparison: Story = {
       </div>
       
       <div style={{ marginTop: tokens.spacing[10], padding: tokens.spacing[8], backgroundColor: tokens.semantic.background.secondary, borderRadius: tokens.borderRadius.md }}>
-        <Heading level={3}>Key Differences:</Heading>
+        <Text component="h3" size="lg" fw="semibold">Key Differences:</Text>
         <div style={{ marginTop: tokens.spacing[4], display: 'grid', gridTemplateColumns: '1fr 1fr', gap: tokens.spacing[6] }}>
           <div>
             <Text fw="semibold" size="sm" style={{ marginBottom: tokens.spacing[3] }}>Before (Problems):</Text>


### PR DESCRIPTION
## Purpose
Fix spacing-related stories/components by replacing the non-existent Heading component with the Text component, as requested by the user who noted there is no Heading component available.

## Code changes
- **Import updates**: Replaced `CustomCard` import with `Card` import in both spacing story files
- **Component replacements**: Converted all `<Heading>` elements to `<Text>` components with appropriate props:
  - `<Heading level={1}>` → `<Text component="h1" size="3xl" fw="bold">`
  - `<Heading level={2}>` → `<Text component="h2" size="2xl" fw="semibold">`
  - `<Heading level={3}>` → `<Text component="h3" size="lg" fw="semibold">`
- **Card component updates**: Replaced `CustomCard` with `Card` and updated padding props to use design system values
- **Code cleanup**: Removed extra blank lines for cleaner imports

Files modified:
- `src/stories/SpacingGuidelines.stories.tsx`
- `src/stories/SpacingIssues.stories.tsx`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/24a15d95f4bd43dfa7a60a61230554cc/spark-haven)

👀 [Preview Link](https://24a15d95f4bd43dfa7a60a61230554cc-spark-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>24a15d95f4bd43dfa7a60a61230554cc</projectId>-->
<!--<branchName>spark-haven</branchName>-->